### PR TITLE
Allow multiple db_dirs per test

### DIFF
--- a/python-opentimestamps/opentimestamps/tests/core/test_git.py
+++ b/python-opentimestamps/opentimestamps/tests/core/test_git.py
@@ -24,17 +24,19 @@ from opentimestamps.core.git import *
 class Test_GitTreeTimestamper(unittest.TestCase):
 
     def setUp(self):
-        self.db_dir = tempfile.TemporaryDirectory()
+        self.db_dirs = []
 
     def tearDown(self):
-        self.db_dir.cleanup()
-        del self.db_dir
+        for d in self.db_dirs:
+            d.cleanup()
+        del self.db_dirs
 
     def make_stamper(self, commit):
         # Yes, we're using our own git repo as the test data!
         repo = git.Repo(__file__ + '../../../../../')
-
-        db = dbm.open(self.db_dir.name + '/db', 'c')
+        db_dir = tempfile.TemporaryDirectory()
+        self.db_dirs.append(db_dir)
+        db = dbm.open(db_dir.name + '/db', 'c')
         tree = repo.commit(commit).tree
         return GitTreeTimestamper(tree, db=db)
 


### PR DESCRIPTION
Calling make_stamper() in a test more than once yields an error in the
`dbm.open()` call. This causes `tests_blobs()` to fail.

Fixed by creating a new db_dir in every make_stamper() call and
cleaning them all up in tearDown().

Fixes #8