### PR TITLE
Return 202 Accepted for pending commitments

### DIFF
--- a/otsserver/rpc.py
+++ b/otsserver/rpc.py
@@ -67,19 +67,19 @@ class RPCRequestHandler(http.server.BaseHTTPRequestHandler):
         try:
             timestamp = self.calendar[commitment]
         except KeyError:
-            self.send_response(404)
-            self.send_header('Content-type', 'text/plain')
 
             # Pending?
             reason = self.calendar.stamper.is_pending(commitment)
             if reason:
                 reason = reason.encode()
 
+                self.send_response(202)
                 # The commitment is pending, so its status will change soonish
                 # as blocks are found.
                 self.send_header('Cache-Control', 'public, max-age=60')
 
             else:
+                self.send_response(404)
                 # The commitment isn't in this calendar at all. Clients only
                 # get specific commitments from servers, so in the current
                 # implementation there's no reason why this response would ever
@@ -87,6 +87,7 @@ class RPCRequestHandler(http.server.BaseHTTPRequestHandler):
                 self.send_header('Cache-Control', 'public, max-age=3600')
                 reason = b'Not found'
 
+            self.send_header('Content-type', 'text/plain')
             self.end_headers()
             self.wfile.write(reason)
             return


### PR DESCRIPTION
This will make it easier for client code to distinguish between both states. A production-ready solution should probably return an entity (possibly in JSON) with specified error code and message.

`202 Accepted` seems to fit the bill here. See https://tools.ietf.org/html/rfc2616#section-10.2.3