### PR TITLE
Adding travis build

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ mode.
 
 ## Requirements
 
-* python-bitcoinlib v0.6.1
+* python-bitcoinlib v0.7.0
 * leveldb
 
 

--- a/otsd
+++ b/otsd
@@ -76,6 +76,10 @@ btc_net_group.add_argument('--btc-regtest', dest='btc_net', action='store_const'
 args = parser.parse_args()
 args.parser = parser
 
+directory = os.path.expanduser("~/.otsd")
+if not os.path.exists(directory):
+    os.makedirs(directory)
+
 debugfile = os.path.expanduser(args.debug_file)
 handler = logging.handlers.RotatingFileHandler(filename=debugfile, maxBytes=args.debug_file_max_size)
 logger = logging.getLogger('')

--- a/otsserver/tests/test_calendar.py
+++ b/otsserver/tests/test_calendar.py
@@ -30,7 +30,7 @@ class Test_LevelDbCalendar(unittest.TestCase):
             t = Timestamp(b'foo')
 
             self.assertNotIn(b'foo', cal)
-            cal.add(t)
+            cal.add_timestamps([t])
             self.assertIn(b'foo', cal)
 
     def test_chain_timestamp(self):
@@ -42,7 +42,7 @@ class Test_LevelDbCalendar(unittest.TestCase):
             t2 = t1.ops.add(OpAppend(b'bar'))
             t3 = t2.ops.add(OpAppend(b'baz'))
 
-            cal.add(t1)
+            cal.add_timestamps([t1])
             self.assertIn(b'foo', cal)
             self.assertIn(b'foobar', cal)
             self.assertIn(b'foobarbaz', cal)
@@ -59,7 +59,7 @@ class Test_LevelDbCalendar(unittest.TestCase):
             merkle_tip = make_merkle_tree(roots)
 
             for root in roots:
-                cal.add(root)
+                cal.add_timestamps([root])
 
                 self.assertIn(merkle_tip.msg, cal)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 python-bitcoinlib>=0.7.0
 GitPython>=2.0.8
 leveldb>=0.20
+pysha3>=1.0.2


### PR DESCRIPTION
Adding travis support which requires the travis definition .travis.yml and the
requirements.txt
After adding the travis build I noticed a LevelDb test was missing an upgrade after adding the batch mode of multiple timestamps
There is also an old commit creating the .otsd dir if missing