### PR TITLE
__do_bitcoin() now outputs a stack trace on errors

### DIFF
--- a/otsserver/stamper.py
+++ b/otsserver/stamper.py
@@ -400,7 +400,7 @@ class Stamper:
                 # connection, and python-bitcoinlib doesn't have great handling
                 # of that. In our case we should be safe to just retry as
                 # __do_bitcoin() is fairly self-contained.
-                logging.error("__do_bitcoin() failed: %r" % exp)
+                logging.error("__do_bitcoin() failed: %r" % exp, exc_info=True)
 
             self.exit_event.wait(1)
 


### PR DESCRIPTION
I'm in the middle of installing ots server and I'm having trouble, so I added this to better troubleshoot.

The errors logs went from being:
```
__do_bitcoin() failed: AssertionError()
```

to:
```
__do_bitcoin() failed: AssertionError()
Traceback (most recent call last):
  File "/home/vincent/opentimestamps-server/otsserver/stamper.py", line 395, in __loop
    self.__do_bitcoin()
  File "/home/vincent/opentimestamps-server/otsserver/stamper.py", line 311, in __do_bitcoin
    assert self.pending_commitments
AssertionError
```

Overall a pretty trivial change.
