### PR TITLE
document & fix assert discrepancy

### DIFF
--- a/otsd
+++ b/otsd
@@ -61,7 +61,7 @@ parser.add_argument("--btc-min-relay-feerate", metavar='FEEPERKB', type=float,
                     help="Minimum relay feerate (default: %(default).6f BTC/KB)")
 parser.add_argument("--btc-min-confirmations", metavar='N', type=int,
                     default=6,
-                    help="Confirmations required before we save a Bitcoin timestamp permanently (default: %(default)d)")
+                    help="Confirmations required before we save a Bitcoin timestamp permanently, must be greater than 1 (default: %(default)d)")
 parser.add_argument("--btc-min-tx-interval", metavar='SECONDS', type=int,
                     default=600,
                     help="Minimum interval between timestamp transactions (default: %(default)d seconds)")

--- a/otsserver/stamper.py
+++ b/otsserver/stamper.py
@@ -427,7 +427,7 @@ class Stamper:
 
         self.relay_feerate = relay_feerate
         self.min_confirmations = min_confirmations
-        assert self.min_confirmations > 0
+        assert self.min_confirmations > 1
         self.min_tx_interval = min_tx_interval
         self.max_fee = max_fee
         self.max_pending = max_pending


### PR DESCRIPTION
As I mentioned in the mailing list, there is an assert for --btc-min-confirmations>1 in __do_bitcoin() and one for --btc-min-confirmations>0 in __init__(). I made both to be at the biggest constraint and I documented it in argparse.

I'm not sure yet if it can be problematic to run at --btc-min-confirmations=1. If it is not, I will update both to be at --btc-min-confirmations>0. Anyway that is a bit of a corner case, because it will be quite expensive to run it this way on mainnet.