### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-python-bitcoinlib>=0.7.0
+python-bitcoinlib==0.7.0
 GitPython>=2.0.8
 leveldb>=0.20
 pysha3>=1.0.2


### PR DESCRIPTION
until we fully upgrade to segwit, use specific version of python-bitcoinlib to avoid
https://github.com/opentimestamps/opentimestamps-server/issues/17