### PR TITLE
External tx

### DIFF
--- a/otsserver/rpc.py
+++ b/otsserver/rpc.py
@@ -180,7 +180,15 @@ This address changes after every donation.
 
         elif self.path.startswith('/timestamp/'):
             self.get_timestamp()
-
+        elif self.path == '/tip':
+            msg = self.calendar.stamper.unconfirmed_txs[-1].tip_timestamp.msg
+            if msg is not None:
+                self.send_response(200)
+                self.send_header('Content-type', 'application/octet-stream')
+                self.end_headers()
+                self.wfile.write(msg)
+            else:
+                self.send_response(404)
         else:
             self.send_response(404)
             self.send_header('Content-type', 'text/plain')

--- a/otsserver/stamper.py
+++ b/otsserver/stamper.py
@@ -497,7 +497,7 @@ class Stamper:
             for height, ttx in self.txs_waiting_for_confirmation.items():
                for commitment_timestamp in ttx.commitment_timestamps:
                     if commitment == commitment_timestamp.msg:
-                        return "Timestamped by transaction %s; waiting for %d confirmations" % (b2lx(ttx.tx.GetTxid()), self.min_confirmations)
+                        return "Timestamped by transaction %s; waiting for %d confirmations" % (b2lx(ttx.tx.GetTxid()), self.min_confirmations-1)
 
             else:
                 return False

--- a/otsserver/stamper.py
+++ b/otsserver/stamper.py
@@ -390,7 +390,7 @@ class Stamper:
         # Send the first transaction even if we don't have a new block
         if prev_tx and (new_blocks or not self.unconfirmed_txs):
             (tip_timestamp, commitment_timestamps) = self.__pending_to_merkle_tree(len(self.pending_commitments))
-
+            logging.debug("New tip is %s" % b2x(tip_timestamp.msg))
             # make_merkle_tree() seems to take long enough on really big adds
             # that the proxy dies
             proxy = bitcoin.rpc.Proxy()

--- a/otsserver/stamper.py
+++ b/otsserver/stamper.py
@@ -50,7 +50,7 @@ def make_btc_block_merkle_tree(blk_txids):
     return digests[0]
 
 
-def make_timestamp_from_block(digest, block, blockheight, serde_txs, *, max_tx_size=1000):
+def make_timestamp_from_block(digest, block, blockheight, serde_txs, *, max_tx_size=500):
     """Make a timestamp for a message in a block with cached serialized txs
     see python-opentimestamps.bitcoin.make_timestamp_from_block
     """

--- a/otsserver/stamper.py
+++ b/otsserver/stamper.py
@@ -79,7 +79,7 @@ def make_timestamp_from_block(digest, block, blockheight, serde_txs, *, max_tx_s
         prefix = serialized_tx[0:i]
         suffix = serialized_tx[i + len(digest):]
 
-        len_smallest_tx_found = len(serialized_tx)ccccccgndgbibidjukdbeeckrberdfnifcedfirrujdg
+        len_smallest_tx_found = len(serialized_tx)
 
 
     if len_smallest_tx_found > max_tx_size:


### PR DESCRIPTION
This PR expose a new endpoint with the last tip calculated by the calendar to allow for external tx.
The make_timestamp_from_block method now return also the tx found in the block which could potentially be not created by the calendar itself.
Fix on the number of confirmation needed when we found the tip in a confirmed tx