### PR TITLE
Switch to mustache for the template & add latest transactions

### DIFF
--- a/otsserver/templates/index.mustache
+++ b/otsserver/templates/index.mustache
@@ -1,0 +1,21 @@
+<html>
+<head>
+    <title>OpenTimestamps Calendar Server</title>
+</head>
+<body>
+<p>This is an <a href="https://opentimestamps.org">OpenTimestamps</a> <a href="https://github.com/opentimestamps/opentimestamps-server">Calendar Server</a> ({{ version }})</p>
+<p>
+Pending commitments: {{ pending_commitments }}</br>
+Transactions waiting for confirmation: {{ txs_waiting_for_confirmation }}</br>
+Most recent timestamp tx: {{ most_recent_tx }} ({{ prior_versions }} prior versions)</br>
+Most recent merkle tree tip: {{ tip }}</br>
+Best-block: {{ best_block }}, height {{ block_height }}</br>
+</br>
+Wallet balance: {{ balance }} BTC</br>
+</p>
+<p>
+You can donate to the wallet by sending funds to: {{ address }}</br>
+This address changes after every donation.
+</p>
+</body>
+</html>

--- a/otsserver/templates/index.mustache
+++ b/otsserver/templates/index.mustache
@@ -17,5 +17,11 @@ Wallet balance: {{ balance }} BTC</br>
 You can donate to the wallet by sending funds to: {{ address }}</br>
 This address changes after every donation.
 </p>
+<p>
+Latest transactions: </br>
+{{#transactions}}
+    {{txid}} </br>
+{{/transactions}}
+</p>
 </body>
 </html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ opentimestamps>=0.2.1
 GitPython>=2.0.8
 leveldb>=0.20
 pysha3>=1.0.2
+pystache>=0.5


### PR DESCRIPTION
This refactors the current html in rpc.py into it's own file using [mustache](https://mustache.github.io/). This should make things much simpler to get a fancy dashboard with a lot of stats.

I've also added a section with the latest timestamping transactions. Using mustache for lists is so much simpler than the built-in format().

Let me know if I should change anything for style/structure/logic/typos.