### PR TITLE
install: add requests to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ GitPython>=2.0.8
 leveldb>=0.20
 pysha3>=1.0.2
 pystache>=0.5
+requests


### PR DESCRIPTION
After setting up a new venv and `pip install -r requirements.txt`:
```
Traceback (most recent call last):
  File "./otsd", line 25, in <module>
    import otsserver.rpc
  File "/Users/michael/github/opentimestamps-server/otsserver/rpc.py", line 25, in <module>
    from otsserver.backup import Backup
  File "/Users/michael/github/opentimestamps-server/otsserver/backup.py", line 25, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'
```