### PR TITLE
handle a tip request when not ready

### DIFF
--- a/otsserver/rpc.py
+++ b/otsserver/rpc.py
@@ -57,7 +57,14 @@ class RPCRequestHandler(http.server.BaseHTTPRequestHandler):
         timestamp.serialize(ctx)
 
     def get_tip(self):
-        msg = self.calendar.stamper.unconfirmed_txs[-1].tip_timestamp.msg
+        try:
+            msg = self.calendar.stamper.unconfirmed_txs[-1].tip_timestamp.msg
+        except:
+            self.send_response(404)
+            self.send_header('Content-type', 'text/plain')
+            self.end_headers()
+            return
+
         if msg is not None:
             self.send_response(200)
             self.send_header('Content-type', 'application/octet-stream')


### PR DESCRIPTION
Currently, when requesting /tip while service is starting a stacktrace is sent to the logs (or stdout if not using as a service):

```
otsd[32579]: Traceback (most recent call last):
otsd[32579]:   File "/usr/lib/python3.5/socketserver.py", line 625, in process_request_thread
otsd[32579]:     self.finish_request(request, client_address)
otsd[32579]:   File "/usr/lib/python3.5/socketserver.py", line 354, in finish_request
otsd[32579]:     self.RequestHandlerClass(request, client_address, self)
otsd[32579]:   File "/usr/lib/python3.5/socketserver.py", line 681, in __init__
otsd[32579]:     self.handle()
otsd[32579]:   File "/usr/lib/python3.5/http/server.py", line 422, in handle
otsd[32579]:     self.handle_one_request()
otsd[32579]:   File "/usr/lib/python3.5/http/server.py", line 410, in handle_one_request
otsd[32579]:     method()
otsd[32579]:   File "/home/btc/ots/otsserver/rpc.py", line 245, in do_GET
otsd[32579]:     self.get_tip()
otsd[32579]:   File "/home/btc/ots/otsserver/rpc.py", line 60, in get_tip
otsd[32579]:     msg = self.calendar.stamper.unconfirmed_txs[-1].tip_timestamp.msg
otsd[32579]: IndexError: list index out of range
```

Using a simple try/except in this PR, server replies with a http/404 which better fits a resource that is just not ready yet.