### PR TITLE
Random wait

### DIFF
--- a/otsd
+++ b/otsd
@@ -61,7 +61,8 @@ parser.add_argument("--btc-min-relay-feerate", metavar='FEEPERKB', type=float,
                     help="Minimum relay feerate (default: %(default).6f BTC/KB)")
 parser.add_argument("--btc-min-confirmations", metavar='N', type=int,
                     default=6,
-                    help="Confirmations required before we save a Bitcoin timestamp permanently, must be greater than 1 (default: %(default)d)")
+                    help="Confirmations required before we save a Bitcoin timestamp permanently, must be greater than 1"
+                         " (default: %(default)d)")
 parser.add_argument("--btc-min-tx-interval", metavar='SECONDS', type=int,
                     default=3600,
                     help="Minimum interval between timestamp transactions (default: %(default)d seconds)")

--- a/otsserver/rpc.py
+++ b/otsserver/rpc.py
@@ -178,7 +178,7 @@ class RPCRequestHandler(http.server.BaseHTTPRequestHandler):
             # need to investigate further, but this seems to work.
             str_wallet_balance = str(proxy._call("getbalance"))
 
-            transactions = proxy._call("listtransactions", "", 1000)
+            transactions = proxy._call("listtransactions", "*", 1000)
             # We want only the confirmed txs containing an OP_RETURN, from most to least recent
             transactions = list(filter(lambda x: x["confirmations"] > 0 and x["amount"] == 0, transactions))
             a_week_ago = (datetime.date.today() - datetime.timedelta(days=7)).timetuple()

--- a/otsserver/rpc.py
+++ b/otsserver/rpc.py
@@ -230,7 +230,7 @@ Latest transactions: </br>
               'best_block': bitcoin.core.b2lx(proxy.getbestblockhash()),
               'block_height': proxy.getblockcount(),
               'balance': str_wallet_balance,
-              'address': str(proxy.getaccountaddress('')),
+              'address': proxy._call("getaccountaddress",""),
               'transactions': transactions[:5],
               'time_between_transactions': time_between_transactions,
               'fees_in_last_week': fees_in_last_week,

--- a/otsserver/stamper.py
+++ b/otsserver/stamper.py
@@ -13,7 +13,7 @@ import collections
 import logging
 import threading
 import time
-import sys
+import random
 import bitcoin.rpc
 
 from bitcoin.core import COIN, b2lx, b2x, x, lx, CTxIn, CTxOut, COutPoint, CTransaction, str_money_value
@@ -370,7 +370,7 @@ class Stamper:
 
                 break
 
-        time_to_next_tx = int(self.last_timestamp_tx + self.min_tx_interval - time.time())
+        time_to_next_tx = int(self.last_timestamp_tx + self.min_tx_interval * random.uniform(1, 2) - time.time())
         if time_to_next_tx > 0:
             # Minimum interval between transactions hasn't been reached, so do nothing
             logging.debug("Waiting %ds before next tx" % time_to_next_tx)


### PR DESCRIPTION
this is based on bech32 branch.

randomize minimum interval between transaction

btc-min-tx-interval is uniformerly chosen in the range:
(btc-min-tx-interval, 2*btc-min-tx-interval)
because every calendar tend to sync timestamps when there is a
blocks burst, this try to desync the calendars to provide more
timely distributed timestamp