### PR TITLE
Qr codes and optional lightning network invoice

### DIFF
--- a/otsd
+++ b/otsd
@@ -52,6 +52,10 @@ parser.add_argument("--rpc-address", type=str,
                     default='localhost',
                     help="RPC address (default: %(default)s)")
 
+parser.add_argument("--lightning-invoice", type=str,
+                    default='',
+                    help="lightning invoice without amount for donations (default: '')")
+
 parser.add_argument("--max-pending", type=int,
                     default=100000,
                     help="Maximum number of pending commitments to timestamp at a time (default: %(default)s)")
@@ -127,7 +131,7 @@ stamper = otsserver.stamper.Stamper(calendar, exit_event,
 
 calendar.stamper = stamper
 
-server = otsserver.rpc.StampServer((args.rpc_address, args.rpc_port), aggregator, calendar)
+server = otsserver.rpc.StampServer((args.rpc_address, args.rpc_port), aggregator, calendar, args.lightning_invoice)
 try:
     server.serve_forever()
 except KeyboardInterrupt:

--- a/otsd
+++ b/otsd
@@ -52,9 +52,8 @@ parser.add_argument("--rpc-address", type=str,
                     default='localhost',
                     help="RPC address (default: %(default)s)")
 
-parser.add_argument("--lightning-invoice", type=str,
-                    default='',
-                    help="lightning invoice without amount for donations (default: '')")
+parser.add_argument("--lightning-invoice-file", type=str,
+                    help="file containing a lightning invoice without amount for donations")
 
 parser.add_argument("--max-pending", type=int,
                     default=100000,
@@ -131,7 +130,7 @@ stamper = otsserver.stamper.Stamper(calendar, exit_event,
 
 calendar.stamper = stamper
 
-server = otsserver.rpc.StampServer((args.rpc_address, args.rpc_port), aggregator, calendar, args.lightning_invoice)
+server = otsserver.rpc.StampServer((args.rpc_address, args.rpc_port), aggregator, calendar, args.lightning_invoice_file)
 try:
     server.serve_forever()
 except KeyboardInterrupt:

--- a/otsserver/rpc.py
+++ b/otsserver/rpc.py
@@ -231,18 +231,20 @@ Wallet balance: {{ balance }} BTC</br>
 
 <p>
 You can donate to the wallet by sending funds to:</br>
-<img src="/qr/{{ address }}" width="250" />
+<img src="/qr/{{ address }}" width="250" /></br>
 <span style="word-break: break-word;">{{ address }}</span>
 </p>
 
 <hr>
 
+{{ #lightning_invoice }}
 <p>
 You can donate through lightning network with the following invoice:</br>
-<img src="/qr/{{ lightning_invoice }}" width="400"/>
+<img src="/qr/{{ lightning_invoice }}" width="400"/></br>
 <span style="word-break: break-word;">{{ lightning_invoice }}</span>
 </p>
 <hr>
+{{ /lightning_invoice }}
 <p>
 Average time between transactions in the last week: {{ time_between_transactions }} </br>
 Fees used in the last week: {{ fees_in_last_week }} BTC</br>

--- a/otsserver/rpc.py
+++ b/otsserver/rpc.py
@@ -64,7 +64,7 @@ class RPCRequestHandler(http.server.BaseHTTPRequestHandler):
         img_stream = buf.getvalue()
         self.send_response(200)
         self.send_header('Content-type', 'image/png')
-        self.send_header('Cache-Control', 'public, max-age=10')
+        self.send_header('Cache-Control', 'public, max-age=31536000')
         self.end_headers()
         self.wfile.write(img_stream)
 

--- a/otsserver/rpc.py
+++ b/otsserver/rpc.py
@@ -214,7 +214,7 @@ class RPCRequestHandler(http.server.BaseHTTPRequestHandler):
 <head>
     <title>OpenTimestamps Calendar Server</title>
 </head>
-<body>
+<body style="word-break: break-word;">
 <p>This is an <a href="https://opentimestamps.org">OpenTimestamps</a> <a href="https://github.com/opentimestamps/opentimestamps-server">Calendar Server</a> (v{{ version }})</p>
 
 <p>
@@ -232,7 +232,7 @@ Wallet balance: {{ balance }} BTC</br>
 <p>
 You can donate to the wallet by sending funds to:</br>
 <img src="/qr/{{ address }}" width="250" /></br>
-<span style="word-break: break-word;">{{ address }}</span>
+<span>{{ address }}</span>
 </p>
 
 <hr>
@@ -241,7 +241,7 @@ You can donate to the wallet by sending funds to:</br>
 <p>
 You can donate through lightning network with the following invoice:</br>
 <img src="/qr/{{ lightning_invoice }}" width="400"/></br>
-<span style="word-break: break-word;">{{ lightning_invoice }}</span>
+<span>{{ lightning_invoice }}</span>
 </p>
 <hr>
 {{ /lightning_invoice }}

--- a/otsserver/rpc.py
+++ b/otsserver/rpc.py
@@ -15,7 +15,8 @@ import qrcode
 import socketserver
 import time
 import pystache
-import datetime 
+import datetime
+import base64
 from functools import reduce
 from io import BytesIO
 
@@ -28,6 +29,14 @@ from opentimestamps.core.serialize import StreamSerializationContext
 
 from otsserver.calendar import Journal
 renderer = pystache.Renderer()
+
+
+def get_qr(data):
+    img = qrcode.make(data)
+    buf = BytesIO()
+    img.save(buf)
+    return base64.b64encode(buf.getvalue())
+
 
 class RPCRequestHandler(http.server.BaseHTTPRequestHandler):
     MAX_DIGEST_LENGTH = 64
@@ -55,18 +64,6 @@ class RPCRequestHandler(http.server.BaseHTTPRequestHandler):
 
         ctx = StreamSerializationContext(self.wfile)
         timestamp.serialize(ctx)
-
-    def get_qr(self):
-        data = self.path[len('/qr/'):]
-        img = qrcode.make(data)
-        buf = BytesIO()
-        img.save(buf)
-        img_stream = buf.getvalue()
-        self.send_response(200)
-        self.send_header('Content-type', 'image/png')
-        self.send_header('Cache-Control', 'public, max-age=31536000')
-        self.end_headers()
-        self.wfile.write(img_stream)
 
     def get_tip(self):
         try:
@@ -187,7 +184,8 @@ class RPCRequestHandler(http.server.BaseHTTPRequestHandler):
             self.send_header('Content-type', 'text/html')
 
             # Humans are likely to be refreshing this, so keep it up-to-date
-            self.send_header('Cache-Control', 'public, max-age=1')
+            # Changed to 5 seconds, otherwise cache was never hit
+            self.send_header('Cache-Control', 'public, max-age=5')
 
             self.end_headers()
 
@@ -212,13 +210,16 @@ class RPCRequestHandler(http.server.BaseHTTPRequestHandler):
             transactions.sort(key=lambda x: x["confirmations"])
 
             lightning_invoice = None
+            lightning_invoice_qr = None
             if self.lightning_invoice_file is not None:
                 try:
                     with open(self.lightning_invoice_file, 'r') as file:
                         lightning_invoice = file.read().strip()
+                        lightning_invoice_qr = get_qr(lightning_invoice)
                 except FileNotFoundError:
                     pass
 
+            address = proxy._call("getaccountaddress", "")
             homepage_template = """<html>
 <head>
     <title>OpenTimestamps Calendar Server</title>
@@ -240,7 +241,7 @@ Wallet balance: {{ balance }} BTC</br>
 
 <p>
 You can donate to the wallet by sending funds to:</br>
-<img src="/qr/{{ address }}" width="250" /></br>
+<img src="data:image/png;base64, {{ address_qr }}" width="250" /></br>
 <span>{{ address }}</span>
 </p>
 
@@ -249,7 +250,7 @@ You can donate to the wallet by sending funds to:</br>
 {{ #lightning_invoice }}
 <p>
 You can donate through lightning network with the following invoice:</br>
-<img src="/qr/{{ lightning_invoice }}" width="400"/></br>
+<img src="data:image/png;base64, {{ lightning_invoice_qr }}" width="400"/></br>
 <span>{{ lightning_invoice }}</span>
 </p>
 <hr>
@@ -278,11 +279,14 @@ Latest mined transactions (confirmations): </br>
               'best_block': bitcoin.core.b2lx(proxy.getbestblockhash()),
               'block_height': proxy.getblockcount(),
               'balance': str_wallet_balance,
-              'address': proxy._call("getaccountaddress",""),
+              'address': address,
+              'address_qr': get_qr(address),
               'transactions': transactions[:10],
               'time_between_transactions': time_between_transactions,
               'fees_in_last_week': fees_in_last_week,
               'lightning_invoice': lightning_invoice,
+              'lightning_invoice_qr': lightning_invoice_qr,
+
             }
             welcome_page = renderer.render(homepage_template, stats)
             self.wfile.write(str.encode(welcome_page))
@@ -321,3 +325,4 @@ class StampServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
 
     def serve_forever(self):
         super().serve_forever()
+

--- a/otsserver/rpc.py
+++ b/otsserver/rpc.py
@@ -210,6 +210,15 @@ class RPCRequestHandler(http.server.BaseHTTPRequestHandler):
             except ZeroDivisionError:
                 time_between_transactions = "N/A"
             transactions.sort(key=lambda x: x["confirmations"])
+
+            lightning_invoice = None
+            if self.lightning_invoice_file is not None:
+                try:
+                    with open(self.lightning_invoice_file, 'r') as file:
+                        lightning_invoice = file.read().strip()
+                except FileNotFoundError:
+                    pass
+
             homepage_template = """<html>
 <head>
     <title>OpenTimestamps Calendar Server</title>
@@ -273,7 +282,7 @@ Latest mined transactions (confirmations): </br>
               'transactions': transactions[:10],
               'time_between_transactions': time_between_transactions,
               'fees_in_last_week': fees_in_last_week,
-              'lightning_invoice': self.lightning_invoice,
+              'lightning_invoice': lightning_invoice,
             }
             welcome_page = renderer.render(homepage_template, stats)
             self.wfile.write(str.encode(welcome_page))
@@ -298,12 +307,12 @@ Latest mined transactions (confirmations): </br>
 
 
 class StampServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
-    def __init__(self, server_address, aggregator, calendar, lightning_invoice):
+    def __init__(self, server_address, aggregator, calendar, lightning_invoice_file):
         class rpc_request_handler(RPCRequestHandler):
             pass
         rpc_request_handler.aggregator = aggregator
         rpc_request_handler.calendar = calendar
-        rpc_request_handler.lightning_invoice = lightning_invoice
+        rpc_request_handler.lightning_invoice_file = lightning_invoice_file
 
         journal = Journal(calendar.path + '/journal')
         rpc_request_handler.backup = Backup(journal, calendar, calendar.path + '/backup_cache')

--- a/otsserver/rpc.py
+++ b/otsserver/rpc.py
@@ -11,13 +11,13 @@
 
 import binascii
 import http.server
-import os
+import qrcode
 import socketserver
-import threading
 import time
 import pystache
 import datetime 
 from functools import reduce
+from io import BytesIO
 
 import bitcoin.core
 from bitcoin.core import b2lx, b2x
@@ -55,6 +55,18 @@ class RPCRequestHandler(http.server.BaseHTTPRequestHandler):
 
         ctx = StreamSerializationContext(self.wfile)
         timestamp.serialize(ctx)
+
+    def get_qr(self):
+        data = self.path[len('/qr/'):]
+        img = qrcode.make(data)
+        buf = BytesIO()
+        img.save(buf)
+        img_stream = buf.getvalue()
+        self.send_response(200)
+        self.send_header('Content-type', 'image/png')
+        self.send_header('Cache-Control', 'public, max-age=10')
+        self.end_headers()
+        self.wfile.write(img_stream)
 
     def get_tip(self):
         try:
@@ -259,6 +271,8 @@ Latest mined transactions (confirmations): </br>
 
         elif self.path.startswith('/timestamp/'):
             self.get_timestamp()
+        elif self.path.startswith('/qr/'):
+            self.get_qr()
         elif self.path == '/tip':
             self.get_tip()
         elif self.path.startswith('/experimental/backup/'):

--- a/otsserver/rpc.py
+++ b/otsserver/rpc.py
@@ -227,15 +227,22 @@ Best-block: {{ best_block }}, height {{ block_height }}</br>
 Wallet balance: {{ balance }} BTC</br>
 </p>
 
+<hr>
+
 <p>
-You can donate to the wallet by sending funds to: {{ address }}</br>
-This address changes after every donation.
+You can donate to the wallet by sending funds to:</br>
+<img src="/qr/{{ address }}" width="250" />
+<span style="word-break: break-word;">{{ address }}</span>
 </p>
+
+<hr>
 
 <p>
 You can donate through lightning network with the following invoice:</br>
-{{lightning_invoice}}
+<img src="/qr/{{ lightning_invoice }}" width="400"/>
+<span style="word-break: break-word;">{{ lightning_invoice }}</span>
 </p>
+<hr>
 <p>
 Average time between transactions in the last week: {{ time_between_transactions }} </br>
 Fees used in the last week: {{ fees_in_last_week }} BTC</br>

--- a/otsserver/rpc.py
+++ b/otsserver/rpc.py
@@ -230,6 +230,10 @@ Latest mined transactions: </br>
     {{txid}} </br>
 {{/transactions}}
 </p>
+
+<p>
+{{lightning_invoice}}
+</p>
 </body>
 </html>"""
 
@@ -246,10 +250,10 @@ Latest mined transactions: </br>
               'transactions': transactions[:5],
               'time_between_transactions': time_between_transactions,
               'fees_in_last_week': fees_in_last_week,
+              'lightning_invoice': self.lightning_invoice,
             }
             welcome_page = renderer.render(homepage_template, stats)
             self.wfile.write(str.encode(welcome_page))
-
 
         elif self.path.startswith('/timestamp/'):
             self.get_timestamp()
@@ -269,7 +273,7 @@ Latest mined transactions: </br>
 
 
 class StampServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
-    def __init__(self, server_address, aggregator, calendar):
+    def __init__(self, server_address, aggregator, calendar, lightning_invoice):
         class rpc_request_handler(RPCRequestHandler):
             pass
         rpc_request_handler.aggregator = aggregator
@@ -279,6 +283,7 @@ class StampServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
         rpc_request_handler.backup = Backup(journal, calendar, calendar.path + '/backup_cache')
 
         super().__init__(server_address, rpc_request_handler)
+        self.lightning_invoice = lightning_invoice
 
     def serve_forever(self):
         super().serve_forever()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ GitPython>=2.0.8
 leveldb>=0.20
 pysha3>=1.0.2
 pystache>=0.5
-requests
-qrcode
-image
+requests==2.2.0
+qrcode==6.1
+image==1.5.27

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ leveldb>=0.20
 pysha3>=1.0.2
 pystache>=0.5
 requests
+qrcode
+image


### PR DESCRIPTION
This PR add an endpoint to create qr codes, which is used in the home to show the qr code of the bitcoin address.

It also add an option `--lightning-invoice-file` which reads a file from the filesystem to show a lightning invoice in the home page for donations, if there is no option or no file the section is not displayed

It also show latest 10 txs instead of 5 with the confirmations, this is intended to more easily compare two calendars, to see if it often happens they use the same block to timestamp