### PR TITLE
added param --debug-file-backup-count

### DIFF
--- a/otsd
+++ b/otsd
@@ -44,6 +44,10 @@ parser.add_argument("--debug-file-max-size", type=int,
                     dest='debug_file_max_size',
                     default=10000000,
                     help="Max size of the debug log (default: %(default)d bytes) ")
+parser.add_argument("--debug-file-backup-count", type=int,
+                    dest='debug_file_backup_count',
+                    default=10,
+                    help="Number of debug log file backups (default: %(default)d bytes) ")
 
 parser.add_argument("--rpc-port", type=int,
                     default=14788,
@@ -86,7 +90,7 @@ if not os.path.exists(directory):
     os.makedirs(directory)
 
 debugfile = os.path.expanduser(args.debug_file)
-handler = logging.handlers.RotatingFileHandler(filename=debugfile, maxBytes=args.debug_file_max_size)
+handler = logging.handlers.RotatingFileHandler(filename=debugfile, maxBytes=args.debug_file_max_size, backupCount=args.debug_file_backup_count)
 fmt = logging.Formatter("%(asctime)-15s %(message)s")
 handler.setFormatter(fmt)
 logger = logging.getLogger('')


### PR DESCRIPTION
	RotatingFileHandler class do not rotate log file if the
	backupCount parameter is zero (that is the default), so
	without this parameter the log rotation is actually disabled.