### PR TITLE
deprecatedrpc removed from bitcoincore 0.18.0 (second proposal)

### DIFF
--- a/otsd
+++ b/otsd
@@ -21,10 +21,12 @@ import time
 
 import bitcoin
 import bitcoin.core
+from bitcoin.wallet import CBitcoinAddress, CBitcoinAddressError
 
 import otsserver.calendar
 import otsserver.rpc
 import otsserver.stamper
+
 
 parser = argparse.ArgumentParser(description="OpenTimestamps Server")
 
@@ -80,6 +82,9 @@ parser.add_argument("--btc-min-tx-interval", metavar='SECONDS', type=int,
 parser.add_argument("--btc-max-fee", metavar='FEE', type=float,
                     default=0.0001,
                     help="Maximum transaction fee (default: %(default).3f BTC)")
+parser.add_argument("--btc-donation-addr", metavar='DONATIONADDRESS', type=str,
+                    default=None,
+                    help="Donation address (default: None)")
 
 btc_net_group = parser.add_mutually_exclusive_group()
 btc_net_group.add_argument('--btc-testnet', dest='btc_net', action='store_const',
@@ -124,6 +129,12 @@ if args.btc_net == 'testnet':
 elif args.btc_net == 'regtest':
     bitcoin.SelectParams('regtest')
 
+if args.btc_donation_addr is not None:
+    try:
+        CBitcoinAddress(args.btc_donation_addr)
+    except CBitcoinAddressError as e:
+        print("error: argument --btc-donation-addr: invalid address: '%s'" % e.args)
+        sys.exit(1)
 
 exit_event = threading.Event()
 
@@ -141,7 +152,7 @@ stamper = otsserver.stamper.Stamper(calendar, exit_event,
 
 calendar.stamper = stamper
 
-server = otsserver.rpc.StampServer((args.rpc_address, args.rpc_port), aggregator, calendar, args.lightning_invoice_file)
+server = otsserver.rpc.StampServer((args.rpc_address, args.rpc_port), aggregator, calendar, args.lightning_invoice_file, args.btc_donation_addr)
 try:
     server.serve_forever()
 except KeyboardInterrupt:

--- a/otsserver/rpc.py
+++ b/otsserver/rpc.py
@@ -279,8 +279,8 @@ Latest mined transactions (confirmations): </br>
               'best_block': bitcoin.core.b2lx(proxy.getbestblockhash()),
               'block_height': proxy.getblockcount(),
               'balance': str_wallet_balance,
-              'address': address,
-              'address_qr': get_qr(address),
+              'address': self.donation_address,
+              'address_qr': get_qr(self.donation_address),
               'transactions': transactions[:10],
               'time_between_transactions': time_between_transactions,
               'fees_in_last_week': fees_in_last_week,
@@ -311,9 +311,9 @@ Latest mined transactions (confirmations): </br>
 
 
 class StampServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
-    def __init__(self, server_address, aggregator, calendar, lightning_invoice_file):
+    def __init__(self, server_address, aggregator, calendar, lightning_invoice_file, btc_donation_address):
         class rpc_request_handler(RPCRequestHandler):
-            pass
+            donation_address = btc_donation_address
         rpc_request_handler.aggregator = aggregator
         rpc_request_handler.calendar = calendar
         rpc_request_handler.lightning_invoice_file = lightning_invoice_file

--- a/otsserver/stamper.py
+++ b/otsserver/stamper.py
@@ -420,18 +420,7 @@ class Stamper:
                 logging.error("Maximum txfee reached!")
                 return
 
-            # before to sign check the btc version
-            # signrawtransaction is deprecated from 0.17.x
-            # and removed from 0.18.x
-            try:
-                r = proxy.call('getnetworkinfo')
-                self.btc_version = int(r['version'])
-            except bitcoin.rpc.JSONRPCError as err:
-                logging.debug("Error calling getnetworkinfo: %r" % err.error)
-            if self.btc_version >= 170000:
-                r = proxy.signrawtransactionwithwallet(unsigned_tx)
-            else:
-                r = proxy.signrawtransaction(unsigned_tx)
+            r = proxy.signrawtransactionwithwallet(unsigned_tx)
             if not r['complete']:
                 logging.error("Failed to sign transaction! r = %r" % r)
                 return
@@ -546,7 +535,6 @@ class Stamper:
         self.txs_waiting_for_confirmation = {}
 
         self.last_timestamp_tx = 0
-        self.btc_version = 0
 
         self.thread = threading.Thread(target=self.__loop)
         self.thread.start()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pystache>=0.5
 requests==2.2.0
 qrcode==6.1
 image==1.5.27
+python-bitcoinlib>=0.10.2,<0.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pystache>=0.5
 requests==2.2.0
 qrcode==6.1
 image==1.5.27
-python-bitcoinlib>=0.10.2,<0.11.0
+#python-bitcoinlib>0.10.2,<0.11.0


### PR DESCRIPTION
signrawtransaction and getaccountaddress were deprecated and now have been fully removed in v0.18

The signrawtransactionwithwallet new method is in python-bitcoinlib 0.10.2 (not required by python-opentimestamps).

The getaccountaddress method has not been replaced in bitcoincore, so there is a new parameter of otsd to set a static address for donation.

The listtransactions method is already fixed by @Rcasatta d5eb607a1cd1fe5b88b081c2b1e58941021bbb6d.

Fixes #45 #56