### PR TITLE
stats output in json format if requested

### DIFF
--- a/otsserver/rpc.py
+++ b/otsserver/rpc.py
@@ -17,6 +17,7 @@ import time
 import pystache
 import datetime
 import base64
+import simplejson
 from functools import reduce
 from io import BytesIO
 
@@ -288,8 +289,11 @@ Latest mined transactions (confirmations): </br>
               'lightning_invoice_qr': lightning_invoice_qr,
 
             }
-            welcome_page = renderer.render(homepage_template, stats)
-            self.wfile.write(str.encode(welcome_page))
+            if self.headers['Accept'] == "application/json":
+                self.wfile.write(str.encode(simplejson.dumps(stats, use_decimal=True, indent=4 * ' ')))
+            else:
+                welcome_page = renderer.render(homepage_template, stats)
+                self.wfile.write(str.encode(welcome_page))
 
         elif self.path.startswith('/timestamp/'):
             self.get_timestamp()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pystache>=0.5
 requests==2.2.0
 qrcode==6.1
 image==1.5.27
+simplejson==3.16.0


### PR DESCRIPTION
    If client request header has "Accept: application/json"
    output stats in json format.
    Easy to parse for monitor software like Nagios.
    Useful to observe more details debugging client side.
    Example usage: curl -H 'Accept: application/json' <uri>

    Fix #41 (WEB-UI enhancement: more info on last transactions)