### PR TITLE
Catch some common bitcoin.rpc.proxy error

### DIFF
--- a/otsserver/rpc.py
+++ b/otsserver/rpc.py
@@ -179,7 +179,10 @@ class RPCRequestHandler(http.server.BaseHTTPRequestHandler):
 
             self.end_headers()
 
-            proxy = bitcoin.rpc.Proxy()
+            try:
+                proxy = bitcoin.rpc.Proxy()
+            except Exception as err:
+                return
 
             # FIXME: Unfortunately getbalance() doesn't return the right thing;
             # need to investigate further, but this seems to work.

--- a/otsserver/stamper.py
+++ b/otsserver/stamper.py
@@ -484,6 +484,17 @@ class Stamper:
 
             try:
                 self.__do_bitcoin()
+            except bitcoin.rpc.InWarmupError as warmuperr:
+                logging.info("Bitcoincore is warming up: %r" % warmuperr)
+                time.sleep(5)
+            except ValueError as err:
+                # If not caused by misconfiguration this error in bitcoinlib
+                # usually occurs when bitcoincore is not started
+                if str(err).startswith('Cookie file unusable'):
+                    logging.error("Proxy Authentication Error: Is bitcoincore running?: %r" % err)
+                    time.sleep(5)
+                else:
+                    logging.error("__do_bitcoin() failed: %r" % exp, exc_info=True)
             except Exception as exp:
                 # !@#$ Python.
                 #


### PR DESCRIPTION
    The aim is just to reduce garbage in log files