### PR TITLE
show lightning qr code in upper case

### DIFF
--- a/otsserver/rpc.py
+++ b/otsserver/rpc.py
@@ -215,7 +215,7 @@ class RPCRequestHandler(http.server.BaseHTTPRequestHandler):
                 try:
                     with open(self.lightning_invoice_file, 'r') as file:
                         lightning_invoice = file.read().strip()
-                        lightning_invoice_qr = get_qr(lightning_invoice)
+                        lightning_invoice_qr = get_qr(lightning_invoice.upper())
                 except FileNotFoundError:
                     pass
 


### PR DESCRIPTION
Changed only for lightning qr because the bitcoin one could be not bech32 (and already quite small anyway)