### PR TITLE
Updates after memory issue

### DIFF
--- a/otsserver/backup.py
+++ b/otsserver/backup.py
@@ -65,7 +65,7 @@ class Backup:
                 # according to https://docs.python.org/3/library/exceptions.html#IndexError IndexError is the more
                 # appropriate exception for this case
                 raise IndexError
-            if i % 100 == 0:
+            if i % 1000 == 0:
                 logging.debug("Got commitment " + str(i) + ":" + b2x(self.journal[i]))
 
         logging.debug("map len " + str(len(backup_map)) + " start:" + str(start) + " end:" + str(end))

--- a/otsserver/calendar.py
+++ b/otsserver/calendar.py
@@ -200,6 +200,7 @@ class LevelDbCalendar:
                 logging.debug("Added %d timestamps to LevelDB; %f stamps/second" %
                                 (n, 10000.0 / (now - last)))
                 last = now
+        del batch_cache
 
         self.db.Write(batch, sync = True)
         logging.debug("Done LevelDbCalendar.add_timestamps(), added %d timestamps total" % n)

--- a/otsserver/stamper.py
+++ b/otsserver/stamper.py
@@ -349,9 +349,9 @@ class Stamper:
 
                 mined_tx.tip_timestamp.merge(block_timestamp)
 
+                logging.debug("Removing %d commitments from pending" % (unconfirmed_tx.n))
                 for commitment in tuple(self.pending_commitments)[0:unconfirmed_tx.n]:
                     self.pending_commitments.remove(commitment)
-                    logging.debug("Removed commitment %s from pending" % b2x(commitment))
 
                 assert self.min_confirmations > 1
                 logging.info("Success! %d commitments timestamped, now waiting for %d more confirmations" %
@@ -473,7 +473,7 @@ class Stamper:
                 # Is this commitment already stamped?
                 if commitment not in self.calendar:
                     self.pending_commitments.add(commitment)
-                    if idx % 100 == 0:
+                    if idx % 1000 == 0:
                         logging.debug('Added %s (idx %d) to pending commitments; %d total'
                                       % (b2x(commitment), idx, len(self.pending_commitments)))
                 else:


### PR DESCRIPTION
Had some issues with Finney instance, the calendar was restarted by systemd after finishing system memory. 

Last log printed was from line:
```
logging.debug("Added %d timestamps to LevelDB; %f stamps/second" %
                                (n, 10000.0 / (now - last)))
```
After closing some other process in the system the calendar completed the ~82k commitments and by monitoring the system I've seen memory was close to 2GB during.

```
self.db.Write(batch, sync = True)
```

b58264f  should release some memory before the write to db.

The other commit is to do less logging

