### PR TITLE
Update otsd.service

### DIFF
--- a/contrib/systemd/otsd.service
+++ b/contrib/systemd/otsd.service
@@ -8,6 +8,7 @@ Group=ots
 ExecStartPre=/bin/bash /usr/local/bin/bitcoind-ready.sh
 ExecStart=/home/ots/opentimestamps-server/otsd -v
 Restart=on-failure
+LimitNOFILE=4096
 
 KillSignal=SIGINT
 


### PR DESCRIPTION
systemd launched process ignores OS limits and defaults to 1024 which could become a problem on calendars with many values saved in leveldb. Calendar Finney hit 1024 max open files, 4096 seems reasonable