### PR TITLE
dust alined to bitcoincore definition

### DIFF
--- a/otsserver/stamper.py
+++ b/otsserver/stamper.py
@@ -177,7 +177,8 @@ def listunspent(proxy, minconf=0, maxconf=999999):
 
 def find_unspent(proxy):
     def sort_filter_unspent(unspent):
-        DUST = 0.001 * COIN
+        # https://github.com/bitcoin/bitcoin/blob/master/src/policy/policy.cpp
+        DUST = 0.00000546 * COIN
         return sorted(filter(lambda x: x['amount'] > DUST and x['spendable'], unspent),
                       key=lambda x: x['amount'])
 


### PR DESCRIPTION
    "Dust" is defined in terms of dustRelayFee,
    which has units satoshis-per-kilobyte.
    If you'd pay more in fees than the value of the output
    to spend something, then we consider it dust.
    A typical spendable non-segwit txout is 34 bytes big, and will
    need a CTxIn of at least 148 bytes to spend:
    so dust is a spendable txout less than
    182*dustRelayFee/1000 (in satoshis).
    546 satoshis at the default rate of 3000 sat/kB.
    A typical spendable segwit txout is 31 bytes big, and will
    need a CTxIn of at least 67 bytes to spend:
    so dust is a spendable txout less than
    98*dustRelayFee/1000 (in satoshis).
    294 satoshis at the default rate of 3000 sat/kB.

    https://github.com/bitcoin/bitcoin/blob/master/src/policy/policy.cpp