### PR TITLE
Specify version of `python-bitcoinlib>=0.12.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ requests>=2.21
 qrcode==6.1
 image==1.5.27
 simplejson==3.16.0
+python-bitcoinlib>=0.12.0


### PR DESCRIPTION
the version specified in opentimestamps is >=0.9.0 which doesn't contain parsing of bech32 addresses and the proxy doesn't contain signrawtransactionwithwallet