### PR TITLE
Add Vary header to make intermediate caches aware of content negotiation

### DIFF
--- a/otsserver/rpc.py
+++ b/otsserver/rpc.py
@@ -198,6 +198,7 @@ class RPCRequestHandler(http.server.BaseHTTPRequestHandler):
             # Humans are likely to be refreshing this, so keep it up-to-date
             # Changed to 5 seconds, otherwise cache was never hit
             self.send_header('Cache-Control', 'public, max-age=5')
+            self.send_header('Vary', 'Accept')
 
             self.end_headers()
 


### PR DESCRIPTION
The cache for the root page is filled without awareness of content negotiation, so when there is a hit you can get an `text/html` response when you requested `application/json` or viceversa.

Adding a Vary header should help prevent this issue in most configurations, but the specific behavior should be confirmed with the actual reverse proxy settings.