### PR TITLE
Remove unneeded dep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,5 @@ leveldb>=0.20
 pystache>=0.5
 requests>=2.21
 qrcode==6.1
-image==1.5.27
 simplejson==3.16.0
 python-bitcoinlib>=0.12.1,<0.13.0


### PR DESCRIPTION
I didn't test this on a running calendar, however, I can find no reference of using image dep in the python source