### PR TITLE
Fix install error on Python 3.12

### DIFF
--- a/otsserver/backup.py
+++ b/otsserver/backup.py
@@ -15,7 +15,7 @@ from opentimestamps.core.op import Op
 from opentimestamps.core.serialize import BytesSerializationContext, BytesDeserializationContext, TruncationError, \
     StreamSerializationContext
 import bitcoin.rpc
-import leveldb
+import plyvel
 import logging
 import socketserver
 import http.server
@@ -318,10 +318,10 @@ class AskBackup(threading.Thread):
                         break
                 assert next_key in attestations
 
-            batch = leveldb.WriteBatch()
+            batch = self.db.db.write_batch(sync=True)
             for key, value in kv_map.items():
-                batch.Put(key, value)
-            self.db.db.Write(batch, sync=True)
+                batch.put(key, value)
+            batch.write()
 
             last_known = last_known + 1
             try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 opentimestamps>=0.3.0,<0.5.0
-leveldb>=0.20
+plyvel>=1.5.1
 pystache>=0.5
 requests>=2.21
 qrcode==6.1


### PR DESCRIPTION
Running `pip install -r requirements.txt` on Python 3.12 fails due to `leveldb` using the removed PyUnicode_AS_UNICODE macro:
```
      /usr/include/python3.12/ceval.h:132:37: note: declared here
        132 | Py_DEPRECATED(3.9) PyAPI_FUNC(void) PyEval_InitThreads(void);
            |                                     ^~~~~~~~~~~~~~~~~~
      aarch64-linux-gnu-g++ -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O2 -Wall -fPIC -I/home/ubuntu/tmp/opentimestamps-server/.venv/include -I/usr/include/python3.12 -c leveldb_object.cc -o build/temp.linux-aarch64-cpython-312/leveldb_object.o -I./leveldb/include -I./leveldb -I./snappy -I. -fno-builtin-memcmp -O2 -fPIC -DNDEBUG -DSNAPPY -pthread -Wall -DOS_LINUX -DLEVELDB_PLATFORM_POSIX
      leveldb_object.cc: In function ‘int pyleveldb_str_eq(PyObject*, const char*)’:
      leveldb_object.cc:795:33: error: ‘PyUnicode_AS_UNICODE’ was not declared in this scope; did you mean ‘PyUnicode_AsUCS4’?
        795 |                 Py_UNICODE* c = PyUnicode_AS_UNICODE(p);
            |                                 ^~~~~~~~~~~~~~~~~~~~
            |                                 PyUnicode_AsUCS4
      error: command '/usr/bin/aarch64-linux-gnu-g++' failed with exit code 1
      [end of output]
 ```
 
`leveldb` also appears unmaintained. Replaced it with `plyvel` in `requirements.txt`, which is maintained and compatible.