### PR TITLE
Bound fee bumping so persistent -26 rejections can't brick the stamper

### DIFF
--- a/otsserver/stamper.py
+++ b/otsserver/stamper.py
@@ -11,6 +11,7 @@
 
 import collections
 import logging
+import math
 import threading
 import time
 import random
@@ -248,9 +249,17 @@ class Stamper:
         bumped appropriately.
         """
 
-        delta_fee = int((old_tx.calc_weight() + 3)/4 * relay_feerate)
-
         old_change_txout = old_tx.vout[0]
+
+        # A non-finite feerate (e.g. a fee-bump that overflowed to inf; see
+        # #114/#116) would crash int() with OverflowError and silently brick
+        # the stamper. Guard it: an infinite feerate means "more fee than the
+        # change can possibly pay", so fall through to the minimal, no-change
+        # transaction below instead of raising.
+        if math.isfinite(relay_feerate):
+            delta_fee = int((old_tx.calc_weight() + 3)/4 * relay_feerate)
+        else:
+            delta_fee = old_change_txout.nValue
 
         if old_change_txout.nValue - delta_fee > DUST:
             return CTransaction(old_tx.vin,
@@ -484,6 +493,21 @@ class Stamper:
                     # Insufficient priority - basically means we didn't
                     # pay enough, so try again with a higher feerate
                     bump_feerate *= 1.25
+
+                    # Bound the fee bumping. If the node keeps rejecting txs
+                    # with -26 (which can happen persistently, e.g. on testnet
+                    # when local relay policy disagrees with our feerate), an
+                    # unbounded bump_feerate climbs every iteration until it
+                    # overflows to inf and crashes __update_timestamp_tx(),
+                    # silently bricking the calendar (#114/#116). Once a bumped
+                    # fee would exceed max_fee there is nothing to gain from
+                    # retrying this cycle, so give up cleanly and let the next
+                    # tick start fresh -- the same outcome as the fee > max_fee
+                    # check above, just reached before the tx is signed again.
+                    vsize = (unsigned_tx.calc_weight() + 3) // 4
+                    if bump_feerate * vsize > self.max_fee:
+                        logging.error("Maximum txfee reached while fee bumping!")
+                        return
                     continue
 
                 else:

--- a/otsserver/tests/test_stamper.py
+++ b/otsserver/tests/test_stamper.py
@@ -1,0 +1,57 @@
+# Copyright (C) 2016 The OpenTimestamps developers
+#
+# This file is part of the OpenTimestamps Server.
+#
+# It is subject to the license terms in the LICENSE file found in the top-level
+# directory of this distribution.
+#
+# No part of the OpenTimestamps Server including this file, may be copied,
+# modified, propagated, or distributed except according to the terms contained
+# in the LICENSE file.
+
+import unittest
+
+from bitcoin.core import CTxIn, CTxOut, COutPoint, CTransaction, lx
+from bitcoin.core.script import CScript, OP_RETURN
+
+from otsserver.stamper import Stamper, DUST
+
+# __update_timestamp_tx is a name-mangled private static method
+_update_timestamp_tx = Stamper._Stamper__update_timestamp_tx
+
+
+def _make_old_tx(change_value):
+    """A minimal timestamp tx: one input, a change output (vout[0]) + OP_RETURN"""
+    txin = CTxIn(COutPoint(lx('00' * 32), 0), nSequence=0xfffffffe)
+    change = CTxOut(change_value, CScript([b'\x00' * 20]))
+    commitment = CTxOut(0, CScript([OP_RETURN, b'\x11' * 32]))
+    return CTransaction([txin], [change, commitment])
+
+
+class Test_update_timestamp_tx(unittest.TestCase):
+    def test_normal_feerate_keeps_change(self):
+        old_tx = _make_old_tx(100000)
+        new_tx = _update_timestamp_tx(old_tx, b'\x22' * 32, 0, 1)  # 1 sat/vB
+        self.assertEqual(len(new_tx.vout), 2)  # change output preserved
+        self.assertGreater(new_tx.vout[0].nValue, DUST)
+        self.assertLess(new_tx.vout[0].nValue, 100000)
+
+    def test_large_feerate_drops_change(self):
+        # A feerate whose delta_fee eats the whole change collapses to the
+        # minimal single-OP_RETURN transaction (no negative-value output).
+        old_tx = _make_old_tx(100000)
+        new_tx = _update_timestamp_tx(old_tx, b'\x22' * 32, 0, 10 ** 9)
+        self.assertEqual(len(new_tx.vout), 1)
+        self.assertEqual(new_tx.vout[0].nValue, 0)
+
+    def test_infinite_feerate_does_not_overflow(self):
+        # Regression for #114/#116: a fee-bump that overflowed to inf must not
+        # raise OverflowError (which crashed the stamper and bricked the
+        # calendar); it degrades to the minimal transaction instead.
+        old_tx = _make_old_tx(100000)
+        new_tx = _update_timestamp_tx(old_tx, b'\x22' * 32, 0, float('inf'))
+        self.assertEqual(len(new_tx.vout), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #114. Likely the same underlying cause as #116 (commitments accepted but never anchored) — see note there.

## The bug

In `Stamper.__do_bitcoin()`'s send-retry loop, every `sendrawtransaction` rejection with RPC error `-26` (insufficient priority) multiplies `bump_feerate` by `1.25` with no upper bound:

```python
if err.error['code'] == -26:
    bump_feerate *= 1.25
    continue
```

If the node keeps returning `-26` — which can persist on testnet when local relay policy disagrees with the calendar's feerate — `bump_feerate` climbs on every iteration until it overflows to `inf`. The next `__update_timestamp_tx()` then crashes:

```
File ".../otsserver/stamper.py", line 251, in __update_timestamp_tx
    delta_fee = int((old_tx.calc_weight() + 3)/4 * relay_feerate)
OverflowError: cannot convert float infinity to integer
```

Once the stamper dies it stops broadcasting, so the calendar keeps accepting commitments (HTTP 200) but never anchors them to Bitcoin. The existing `if fee > self.max_fee: return` safety valve doesn't catch it, because the overflow happens during fee *computation* (inside `__update_timestamp_tx`) before fee *evaluation*, and when the funding UTXO is smaller than `max_fee` the actual fee saturates below `max_fee` so that check never fires.

## The fix

- **Bound the loop (root cause).** Once a bumped feerate would push the delta fee past `max_fee`, give up this cycle cleanly and let the next stamper tick start fresh — the same outcome as the existing `max_fee` check, just reached before the tx is re-signed. `bump_feerate` now stays finite and small (terminates in ~30 iterations at the defaults instead of ~3000+ then crashing).
- **Defense in depth.** `__update_timestamp_tx()` now treats a non-finite feerate as "more fee than the change can pay" and degrades to the minimal no-change transaction instead of raising, so the fee math can never `OverflowError`.
- **Regression test.** `otsserver/tests/test_stamper.py` covers normal / change-consuming / infinite feerates.

No behavior change for finite feerates within `max_fee`.
